### PR TITLE
feat: implement add-task screen and form functionality

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,23 +1,56 @@
 // app/(tabs)/index.tsx
 
-/**
- * Task list screen
- * Renders the list of tasks using FlatList and TaskItem component.
- * Pulls initial data from mockTasks and allows future state updates.
- */
-
-import React, { useState } from 'react';
-import { FlatList, SafeAreaView, Text, View, StyleSheet } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { FlatList, SafeAreaView, Text, View, StyleSheet, Pressable} from 'react-native';
 import { mockTasks } from '../../data/mockTasks';
 import TaskItem from '../../components/TaskItem';
 import { Task } from '../../types/Task';
+import { useRouter, useLocalSearchParams } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { Link } from 'expo-router';
 
+/**
+ * Task list screen (Home screen)
+ * Renders the list of tasks using FlatList and TaskItem component.
+ * Pulls initial data from mockTasks and allows future state updates.
+ */
 export default function TaskListScreen() {
   const [tasks, setTasks] = useState<Task[]>(mockTasks);
+  const router = useRouter();
+  const params = useLocalSearchParams();
+
+  /**
+   * useEffect to handle new task passed via params
+   * Parses the new task and adds it to the state
+   */
+  useEffect(() => {
+    if (params?.newTask) {
+      try {
+        const parsedTask: Task = JSON.parse(params.newTask as string);
+  
+        // Avoid duplicates: check if task already exists
+        const exists = tasks.some((t) => t.id === parsedTask.id);
+        if (!exists) {
+          setTasks((prev) => [parsedTask, ...prev]);
+        }
+        
+      } catch (e) {
+        console.warn('Failed to parse new task:', e);
+      }
+    }
+  }, [params?.newTask]);
 
   return (
     <SafeAreaView style={styles.container}>
-      <Text style={styles.heading}>My Tasks</Text>
+      <View style={styles.header}>
+        <Text style={styles.heading}>My Tasks</Text>
+        <Link href="./add-task" asChild>
+          <Pressable>
+            <Ionicons name="add-circle-outline" size={32} color="black" />
+          </Pressable>
+        </Link>
+      </View>
+
       <FlatList
         data={tasks}
         keyExtractor={(item) => item.id}
@@ -36,6 +69,12 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 24,
     backgroundColor: '#fff',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 16,
   },
   heading: {
     fontSize: 24,

--- a/app/add-task.tsx
+++ b/app/add-task.tsx
@@ -1,0 +1,70 @@
+// app/add-task.tsx
+
+import React, { useState } from 'react';
+import { View, StyleSheet, Alert } from 'react-native';
+import { useRouter } from 'expo-router';
+import { Task } from '../types/Task';
+import TaskFormFields from '../components/TaskFormFields';
+
+/**
+ * AddTaskScreen
+ * 
+ * This screen renders a reusable task form used for creating a new task.
+ * On form submission, it generates a unique ID and navigates back to the home screen,
+ * passing the new task data via router params.
+ */
+export default function AddTaskScreen() {
+  const router = useRouter();
+
+  // Local state for form input fields
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [status, setStatus] = useState<'pending' | 'in progress' | 'completed'>('pending');
+
+  /**
+   * Handles form submission for adding a new task.
+   * Validates input, generates a new task, and navigates back to index.tsx.
+   */
+  const handleAddTask = () => {
+    if (!title.trim()) {
+      Alert.alert('Title is required.');
+      return;
+    }
+
+    const newTask: Task = {
+      id: Date.now().toString(),
+      title,
+      description,
+      status,
+    };
+
+    // Navigate back to home with the new task as stringified param
+    router.replace({
+      pathname: '/',
+      params: { newTask: JSON.stringify(newTask) },
+    });
+  };
+
+  return (
+    <View style={styles.container}>
+      <TaskFormFields
+        title={title}
+        setTitle={setTitle}
+        description={description}
+        setDescription={setDescription}
+        status={status}
+        setStatus={setStatus}
+        onSubmit={handleAddTask}
+        submitLabel="Add Task"
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    backgroundColor: '#fff',
+  },
+});

--- a/components/TaskFormFields.tsx
+++ b/components/TaskFormFields.tsx
@@ -1,0 +1,101 @@
+// components/TaskFormFields.tsx
+
+import React from 'react';
+import { View, Text, TextInput, StyleSheet, Button } from 'react-native';
+import { Task } from '../types/Task';
+
+interface Props {
+  /**
+   * Controlled input values and their setters from parent component.
+   */
+  title: string;
+  setTitle: (value: string) => void;
+  description: string;
+  setDescription: (value: string) => void;
+  status: Task['status'];
+  setStatus: (value: Task['status']) => void;
+
+  /**
+   * Handler function to be called when form is submitted.
+   */
+  onSubmit: () => void;
+
+  /**
+   * Label for the submit button (e.g., "Add Task" or "Save Changes").
+   */
+  submitLabel: string;
+}
+
+/**
+ * TaskFormFields
+ * 
+ * This component renders reusable form fields for creating or editing a task.
+ * Controlled input state is passed from the parent screen (add/edit).
+ */
+export default function TaskFormFields({
+  title,
+  setTitle,
+  description,
+  setDescription,
+  status,
+  setStatus,
+  onSubmit,
+  submitLabel,
+}: Props) {
+  return (
+    <View style={styles.container}>
+      {/* Task Title Input */}
+      <Text style={styles.label}>Title</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="Enter task title"
+        value={title}
+        onChangeText={setTitle}
+      />
+
+      {/* Task Description Input */}
+      <Text style={styles.label}>Description</Text>
+      <TextInput
+        style={[styles.input, styles.textArea]}
+        placeholder="Enter task description"
+        value={description}
+        onChangeText={setDescription}
+        multiline
+      />
+
+      {/* Task Status Input (for now, just a text input) */}
+      <Text style={styles.label}>Status</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="pending / in progress / completed"
+        value={status}
+        onChangeText={(value) => setStatus(value as Task['status'])}
+      />
+
+      {/* Submit Button */}
+      <Button title={submitLabel} onPress={onSubmit} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 16,
+  },
+  label: {
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    borderRadius: 6,
+    fontSize: 16,
+  },
+  textArea: {
+    height: 80,
+    textAlignVertical: 'top',
+  },
+});


### PR DESCRIPTION
### What’s Added
- `/app/add-task.tsx` screen with form submission
- `TaskFormFields` reusable component under `/components`
- Navigation from home screen(`/app/index.tsx`) to add task form

### Behavior
- Clicking "+" icon navigates to `/add-task`
- New task is added to the top of the list with unique ID

### Next Steps
- Reuse `TaskFormFields` for upcoming edit task feature

---
### Note
Due to time constraints and lack of reviewer availability, this PR is being merged under self-review. All changes have been tested locally on both Android and iOS using Expo Go.
