### PR TITLE
feat: delete task functionality with state update on home

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -13,10 +13,10 @@ import { Link } from 'expo-router';
  * Task list screen (Home screen)
  * Renders the list of tasks using FlatList and TaskItem component.
  * Pulls initial data from mockTasks and allows future state updates:
- *  - Adding new tasks via params
+ *  - Adding tasks
  *  - Editing tasks
  *  - Deleting tasks
- *  - Deleting tasks
+ *  - Toggling task status
  */
 export default function TaskListScreen() {
   const [tasks, setTasks] = useState<Task[]>(mockTasks);
@@ -60,6 +60,16 @@ export default function TaskListScreen() {
       }
     }
   }, [params?.newTask, params?.updatedTask]);
+
+/**
+ * Handle deleted tasks
+ */
+  useEffect(() => {
+    if (params?.deletedTaskId) {
+      const taskIdToDelete = String(params.deletedTaskId);
+      setTasks((prev) => prev.filter((t) => t.id !== taskIdToDelete));
+    }
+  }, [params?.deletedTaskId]);
 
   return (
     <SafeAreaView style={styles.container}>

--- a/app/task-details.tsx
+++ b/app/task-details.tsx
@@ -41,10 +41,26 @@ export default function TaskDetailsScreen() {
 
 /**
  * handleDelete
- * Placeholder for future delete functionality
+ * Confirms with user, then routes back to Home passing deletedTaskId
  */
-  const handleDelete = () => {
-    Alert.alert('Delete Task', 'Delete functionality coming soon!');
+const handleDelete = () => {
+  Alert.alert(
+    'Confirm Deletion',
+    'Are you sure you want to delete this task?',
+    [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: () => {
+          router.push({
+            pathname: '/',
+            params: { deletedTaskId: String(id) },
+          });
+        },
+      },
+    ]
+  );
   };
 
   /**


### PR DESCRIPTION
### What’s Added
- Users can now delete tasks directly from the Task Details screen
- Confirmation dialog prevents accidental deletion
- Deleted task is removed from state in the Home screen

### Changes Made
- `task-details.tsx`: Added delete confirmation and routing with `deletedTaskId`
- `index.tsx`: New `useEffect` to filter out tasks by `deletedTaskId` param

_Merging under self-reviews; successfully tested_