### PR TITLE
feat: implement Toggle Task Status with automatic state sync

### DIFF
--- a/app/task-details.tsx
+++ b/app/task-details.tsx
@@ -63,13 +63,41 @@ const handleDelete = () => {
   );
   };
 
-  /**
-   * handleToggleStatus
-   * Placeholder for future toggle status functionality
-   */
-  const handleToggleStatus = () => {
-    Alert.alert('Toggle Status', 'Toggle status feature coming soon!');
+
+/**
+ * handleToggleStatus
+ * Cycles through predefined status values and updates the task
+ */
+const handleToggleStatus = () => {
+  const statusCycle = ['pending', 'in progress', 'completed'];
+  const currentIndex = statusCycle.indexOf(String(status));
+  const nextStatus = statusCycle[(currentIndex + 1) % statusCycle.length];
+
+  const updatedTask = {
+    id: String(id),
+    title: String(title),
+    description: String(description),
+    status: nextStatus,
   };
+
+  Alert.alert(
+    'Status Updated',
+    `Task marked as "${nextStatus}".`,
+    [
+      {
+        text: 'OK',
+        onPress: () => {
+          router.push({
+            pathname: '/',
+            params: {
+              updatedTask: JSON.stringify(updatedTask),
+            },
+          });
+        },
+      },
+    ]
+  );
+};
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
### What's Added
- Users can now toggle task status directly from the Task Details screen
- Status cycles through: `pending → in progress → completed → pending`
- Alert confirms each change before navigating back

### Logic Details
- Toggled task is passed via `updatedTask` param
- `index.tsx` already handles `updatedTask` logic and replaces the task in the list

 _This merging is under self-review; feature has been successfully tested._